### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
 script:
     - python -m pytest tests/
 env:
-    - OAUTH_ID=dummyoauthid
-    - OAUTH_SECRET=dummyoauthsecret
-    - SECRET=dummyapplicationsecret
-    - DATABASE_URL=postgres://postgres:created@localhost/postgres
+    global:
+        - OAUTH_ID=dummyoauthid
+        - OAUTH_SECRET=dummyoauthsecret
+        - SECRET=dummyapplicationsecret
+        - DATABASE_URL=postgres://postgres:created@localhost/postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,8 @@ python:
     - "2.7"
 script:
     - python -m pytest tests/
+env:
+    - OAUTH_ID=dummyoauthid
+    - OAUTH_SECRET=dummyoauthsecret
+    - SECRET=dummyapplicationsecret
+    - DATABASE_URL=postgres://postgres:created@localhost/postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+    - "2.7"
+script:
+    - python -m pytest tests/


### PR DESCRIPTION
Builds should be visible at the [Travis page](https://travis-ci.com/CreatEDHack/cog) for the repo. Runs what is currently set under `make test` with dummy secrets/oauth variables.

Re: #17 